### PR TITLE
Fix model loading error feedback

### DIFF
--- a/OneClickLlm/AvaloniaUI/Presenters/ModelSelectionPresenter.cs
+++ b/OneClickLlm/AvaloniaUI/Presenters/ModelSelectionPresenter.cs
@@ -23,6 +23,9 @@ public partial class ModelSelectionPresenter : PresenterBase
     [NotifyCanExecuteChangedFor(nameof(DeleteSelectedModelCommand))]
     [NotifyCanExecuteChangedFor(nameof(ConfirmSelectionCommand))]
     private ModelInfo? _selectedModel;
+
+    [ObservableProperty]
+    private string? _errorMessage;
     
     public ModelSelectionPresenter(IModelManager modelManager, ILlmService llmService)
     {
@@ -40,8 +43,7 @@ public partial class ModelSelectionPresenter : PresenterBase
         catch(Exception ex)
         {
             // Обработка ошибки, если Ollama не запущен
-            Console.WriteLine($"Error loading models: {ex.Message}");
-            // Можно показать диалоговое окно с ошибкой пользователю
+            ErrorMessage = $"Error loading models: {ex.Message}";
         }
     }
 


### PR DESCRIPTION
## Summary
- add `ErrorMessage` property to `ModelSelectionPresenter`
- surface error message when loading models fails

## Testing
- `dotnet build OneClickLlm.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68627a06ddcc832988b830a33d809a15