### PR TITLE
Ensure http request disposal

### DIFF
--- a/OneClickLlm.Cores/Infrastructure/Services/Interfaces/LLMServices/OllamaLargeLanguageModelService.cs
+++ b/OneClickLlm.Cores/Infrastructure/Services/Interfaces/LLMServices/OllamaLargeLanguageModelService.cs
@@ -61,7 +61,10 @@ namespace OneClickLlm.Core.Services
             };
             
             using var jsonContent = new StringContent(JsonSerializer.Serialize(request, _jsonSerializerOptions), Encoding.UTF8, "application/json");
-            var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/api/chat") { Content = jsonContent };
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/api/chat")
+            {
+                Content = jsonContent
+            };
 
             using var response = await _httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
             response.EnsureSuccessStatusCode();


### PR DESCRIPTION
## Summary
- dispose the HTTP request message in `GenerateResponseStreamAsync`

## Testing
- `dotnet build OneClickLlm.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68627a9b07ec83298cc02d695336e3fc