### PR TITLE
Fix message color bindings

### DIFF
--- a/OneClickLlm/AvaloniaUI/Views/MainWindow.axaml
+++ b/OneClickLlm/AvaloniaUI/Views/MainWindow.axaml
@@ -4,8 +4,9 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:core="using:OneClickLlm.Core.Services"
         xmlns:presenters="using:OneClickLlm.AvaloniaUI.Presenters"
+        xmlns:views="using:OneClickLlm.AvaloniaUI.Views"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
-        x:Class="OneClickLlm.AvaloniaUI.Views.MainWindow" x:DataType="presenters:MainWindowPresenter"
+        x:Class="OneClickLlm.AvaloniaUI.Views.MainWindow" x:DataType="presenters:MainWindowPresenter" x:Name="RootWindow"
         Icon=""
         Title="OneClick LLM"
         WindowStartupLocation="CenterScreen">
@@ -31,10 +32,10 @@
                     <DataTemplate DataType="core:ChatMessage">
                         <Border CornerRadius="8" Padding="10" Margin="5"
                                 HorizontalAlignment="{Binding Role, Converter={StaticResource RoleToAlignmentConverter}}"
-                                Background="{Binding RelativeSource={RelativeSource AncestorType=Window}}">
+                                Background="{Binding DataContext.MessageBackgroundColor, ElementName=RootWindow}">
                             <TextBlock Text="{Binding Content}"
                                        TextWrapping="Wrap"
-                                       Foreground="{Binding RelativeSource={RelativeSource AncestorType=Window}}" />
+                                       Foreground="{Binding DataContext.MessageTextColor, ElementName=RootWindow}" />
                         </Border>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary
- fix color bindings by binding using ElementName

## Testing
- `dotnet build OneClickLlm/OneClickLlm.csproj -v minimal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686288fb6b6c8329804269f2e7cb8035