### PR TITLE
Fix chat message color bindings

### DIFF
--- a/OneClickLlm/AvaloniaUI/Views/MainWindow.axaml
+++ b/OneClickLlm/AvaloniaUI/Views/MainWindow.axaml
@@ -32,10 +32,10 @@
                     <DataTemplate DataType="core:ChatMessage">
                         <Border CornerRadius="8" Padding="10" Margin="5"
                                 HorizontalAlignment="{Binding Role, Converter={StaticResource RoleToAlignmentConverter}}"
-                                Background="{Binding DataContext.MessageBackgroundColor, ElementName=RootWindow}">
+                                Background="{Binding MessageBackgroundColor, ElementName=RootWindow}">
                             <TextBlock Text="{Binding Content}"
                                        TextWrapping="Wrap"
-                                       Foreground="{Binding DataContext.MessageTextColor, ElementName=RootWindow}" />
+                                       Foreground="{Binding MessageTextColor, ElementName=RootWindow}" />
                         </Border>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary
- fix message color bindings in `MainWindow.axaml`

## Testing
- `dotnet build --no-restore` *(fails: Package Avalonia not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628f887c9c8329a147cd4d340e0cfa